### PR TITLE
Automate CLA signing process

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,43 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+permissions:
+  actions: write
+  contents: write # this can be 'read' if the signatures are in remote repository
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # the below token should have repo scope and must be manually added by you in the repository's secret
+          # This token is required only if you have configured to store the signatures in a remote repository/organization
+          # PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/AdityaBiswas321/chat-app/blob/version-2/CLA.md' # e.g. a CLA or a DCO document
+          # branch should not be protected
+          branch: 'version-2'
+          allowlist: AdityaBiswas321
+
+          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
+          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #remote-repository-name: enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
+          #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
+          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
+          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
+          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
+          lock-pullrequest-aftermerge: true
+          #use-dco-flag: true - If you are using DCO instead of CLA

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 
 ## License
+
 This project is licensed under the GNU Affero General Public License v3 (AGPLv3).
 See the [LICENSE](./LICENSE) file for details.
 
 ## Contributing
-Contributions are welcome! Please read our [Contributing Guidelines](CONTRIBUTING.md) and sign the [Contributor License Agreement (CLA)](CLA.md) before submitting a pull request
+
+Contributions are welcome! Please note you will be asked to sign the [Contributor License Agreement (CLA)](CLA.md) the first time you submit a pull request. To sign, simply post a comment in the pull request thread when CLA Assistant asks you to.
 
 
 


### PR DESCRIPTION
Automate CLA signing process using the [CLA Assistant GitHub Action](https://github.com/contributor-assistant/github-action)

P.S. I removed the mention of `CONTRIBUTING.md` from the readme, since this file doesn't yet exist