### PR TITLE
Keep settings & conversation when reloading page + keep user convo history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "@uidotdev/usehooks": "^2.4.1",
         "axios": "^1.7.7",
         "bootstrap": "^5.3.3",
         "react": "^18.3.1",
@@ -4775,6 +4776,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@uidotdev/usehooks": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@uidotdev/usehooks/-/usehooks-2.4.1.tgz",
+      "integrity": "sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/@ungap/structured-clone": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "@uidotdev/usehooks": "^2.4.1",
     "axios": "^1.7.7",
     "bootstrap": "^5.3.3",
     "react": "^18.3.1",

--- a/src/components/Chat/AI.js
+++ b/src/components/Chat/AI.js
@@ -67,18 +67,22 @@ const LLMConnector = ({ onCategorySelect }) => {
       );
 
       if (
-        result.data &&
-        result.data.choices &&
-        result.data.choices.length > 0
+        result?.data?.choices?.length > 0
       ) {
         const apiResponse = result.data.choices[0].message.content;
         setResponse(apiResponse);
 
-        // Append the AI's response to the conversation history
-        addToConversationHistory(selectedCharacter, {
+        // Append the user's message and the AI's response to the conversation history
+        addToConversationHistory(selectedCharacter, [
+          {
+            role: "user",
+            content: message,
+          },
+          {
           role: "assistant",
           content: apiResponse,
-        });
+          }
+        ]);
 
         // Detect and handle the commands from the response
         const lowerCaseResponse = apiResponse.toLowerCase();

--- a/src/context/AppContext.js
+++ b/src/context/AppContext.js
@@ -1,5 +1,6 @@
 import React, { createContext, useState, useContext } from "react";
 import { DEFAULT_CHARACTERS } from "../components/Character/CharacterPrompts"; // Import default characters
+import { useLocalStorage } from "@uidotdev/usehooks";
 
 // Create the Context
 const AppContext = createContext();
@@ -25,17 +26,17 @@ const DEFAULT_FUNCTION_PARAMETERS = {
 
 // Provider Component
 export const AppProvider = ({ children }) => {
-  const [characters, setCharacters] = useState(DEFAULT_CHARACTERS);
-  const [conversationHistories, setConversationHistories] = useState({
+  const [characters, setCharacters] = useLocalStorage("characters", DEFAULT_CHARACTERS);
+  const [conversationHistories, setConversationHistories] = useLocalStorage("conversationHistories", {
     characterbuilder: [],
     mistress: [],
     teacher: [],
     therapist: [],
   });
-  const [selectedCharacter, setSelectedCharacter] = useState("mistress");
-  const [apiKey, setApiKey] = useState("");
-  const [connectionKey, setConnectionKey] = useState("");
-  const [functionParameters, setFunctionParameters] = useState(DEFAULT_FUNCTION_PARAMETERS);
+  const [selectedCharacter, setSelectedCharacter] = useLocalStorage("selectedCharacter", "mistress");
+  const [apiKey, setApiKey] = useLocalStorage("apiKey", "");
+  const [connectionKey, setConnectionKey] = useLocalStorage("connectionKey", "");
+  const [functionParameters, setFunctionParameters] = useLocalStorage("functionParameters", DEFAULT_FUNCTION_PARAMETERS);
 
   // Update function parameters strictly
   const updateFunctionParameters = (functionName, updatedParameters) => {
@@ -100,10 +101,13 @@ export const AppProvider = ({ children }) => {
     }
   };
 
-  const addToConversationHistory = (characterKey, message) => {
+  const addToConversationHistory = (characterKey, messages) => {
     setConversationHistories((prev) => ({
       ...prev,
-      [characterKey]: [...(prev[characterKey] || []), message],
+      [characterKey]: [
+        ...(prev[characterKey] || []),
+        ...(Array.isArray(messages) ? messages : [messages])
+      ],
     }));
   };
 


### PR DESCRIPTION
This PR contains two improvements:
- A QoL feature: the various settings (like API keys, function parameters, character profiles) are stored in localStorage so that they don't reset when the user reloads the page
- The conversation history is preserved the same way as well, and now also includes the user's messages (not just the AI's)
  - The AI's responses improved massively for me once the other half of the conversation was also provided to it as context. Night and day difference. (This is with the `lumi-8b-v2` model through Mancer's OpenAI-compatible API)
  - I changed `addToConversationHistory` to accept an array of messages so both the user's message and AI's message could be stored at once. (React didn't like it when I called `addToConversationHistory` multiple times in the same component; this resulted in it losing the data from the first call and only storing the second. Making it accept an array fixed that.)

Please note that I've only used the default chat page so far, so the other pages might be lacking these improvements. (Might be nice to look into a refactor soon to reduce the amount of duplicate code, I'd be happy to help with that as well! 😊)